### PR TITLE
appveyor.py: Add AppVeyor status provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Supported CI Services
   - Travis
   - Gitlab CI
+  - AppVeyor
 
 ## Usage
 

--- a/org_status/org_hosts/github.py
+++ b/org_status/org_hosts/github.py
@@ -3,11 +3,13 @@ from IGitt.GitHub.GitHubOrganization import GitHubOrganization
 
 from org_status.org_hosts import OrgHost, RepoStatus
 from org_status.status_providers.travis import TravisBuildStatus
+from org_status.status_providers.appveyor import AppVeyorStatus
+from org_status.status_providers import Status
 
 
 class GitHubOrg(OrgHost):
     HostName = 'github'
-    StatusProvider = TravisBuildStatus
+    StatusProvider = [TravisBuildStatus, AppVeyorStatus]
 
     def __init__(self, token, group, **kargs):
         super().__init__(**kargs)
@@ -16,14 +18,34 @@ class GitHubOrg(OrgHost):
         self._token = GitHubToken(token)
         self._org = GitHubOrganization(self._token, self._group)
 
-        self._status_provider = self.StatusProvider(self._group)
+        self._status_provider = []
+        for i in enumerate(self.StatusProvider):
+            self._status_provider.append(self.StatusProvider[i[0]](self._group))
 
     def process_repository(self, repo, branch='master'):
         self.print_status(repo.web_url)
 
         # reliable enough?
         repo_name = repo.web_url.split('/')[-1]
-        repo_status = self._status_provider.get_status(repo_name, branch=branch)
+        repo_status = []
+        for i in enumerate(self._status_provider):
+            repo_status.append(self._status_provider[i[0]]
+                               .get_status(repo_name,
+                                           self.HostName,
+                                           branch=branch))
+
+        # if one result is passing, return that one
+        if Status.PASSING in repo_status:
+            repo_status = Status.PASSING
+        # if statuses are identical, just return one of them
+        elif repo_status[0] == repo_status[1]:
+            repo_status = repo_status[0]
+        # return the failing result out of the 2 results
+        elif Status.FAILING in repo_status:
+            repo_status = Status.FAILING
+        # return the error result out of the 2 results
+        elif Status.ERROR in repo_status:
+            repo_status = Status.ERROR
 
         return RepoStatus(repo.web_url, repo_status)
 

--- a/org_status/org_hosts/gitlab.py
+++ b/org_status/org_hosts/gitlab.py
@@ -23,7 +23,9 @@ class GitLabOrg(OrgHost):
 
         # reliable enough?
         repo_name = '/'.join(repo.web_url.split('/')[4:])
-        repo_status = self._status_provider.get_status(repo_name, branch=branch)
+        repo_status = self._status_provider.get_status(repo_name,
+                                                       self.HostName,
+                                                       branch=branch)
 
         return RepoStatus(repo.web_url, repo_status)
 

--- a/org_status/status_providers/__init__.py
+++ b/org_status/status_providers/__init__.py
@@ -26,10 +26,10 @@ class StatusProvider:
 
         self._group = group
         self._group_url = self.BadgeTemplate.format(
-          group=group, repo='{repo}', branch='{branch}')
+          group=group, repo='{repo}', branch='{branch}', host='{host}')
 
-    def get_badge_url(self, repo, branch='master'):
-        return self._group_url.format(repo=repo, branch=branch)
+    def get_badge_url(self, repo, host, branch='master'):
+        return self._group_url.format(repo=repo, branch=branch, host=host)
 
     def status_from_badge_svg(self, svg):
         svg = svg.lower()

--- a/org_status/status_providers/appveyor.py
+++ b/org_status/status_providers/appveyor.py
@@ -3,9 +3,9 @@ import requests
 from org_status.status_providers import StatusProvider, Status
 
 
-class TravisBuildStatus(StatusProvider):
-    BadgeTemplate = ('https://api.travis-ci.org/{group}'
-                     '/{repo}.svg?branch={branch}')
+class AppVeyorStatus(StatusProvider):
+    BadgeTemplate = ('https://ci.appveyor.com/api/projects/status/{host}/'
+                     '{group}/{repo}?branch={branch}&svg=true')
 
     def get_status(self, repo, host, branch='master'):
         badge_result = requests.get(self.get_badge_url(repo,

--- a/org_status/status_providers/gitlab_ci.py
+++ b/org_status/status_providers/gitlab_ci.py
@@ -7,8 +7,10 @@ class GitLabCIStatus(StatusProvider):
     BadgeTemplate = ('https://gitlab.com/{group}'
                      '/{repo}/badges/{branch}/pipeline.svg')
 
-    def get_status(self, repo, branch):
-        badge_result = requests.get(self.get_badge_url(repo, branch=branch))
+    def get_status(self, repo, host, branch):
+        badge_result = requests.get(self.get_badge_url(repo,
+                                                       host,
+                                                       branch=branch))
 
         if badge_result.status_code == 404:
             return Status.UNKNOWN


### PR DESCRIPTION
Add AppVeyor status provider by using its badge url.

Closes https://github.com/ksdme/org-status/issues/12

Simply added the status provider. I have not hooked it up to an `org_host`, as it doesn't _seem_ like it's possible to have multiple status providers for each.

By the looks of it, Appveyor doesn't support Gitlab in its badges, so we'd only be able to hook it up to Github anyway.