### PR TITLE
Add option to order results by last commit date

### DIFF
--- a/org_status/encoders/gitman.py
+++ b/org_status/encoders/gitman.py
@@ -14,6 +14,6 @@ class GitManEncoder(RepoListEncoder):
             name = parse(repo.web_url).repo
             yml_data['sources'].append({'name': name,
                                         'repo': repo.web_url,
-                                        'rev': 'master'})
-
+                                        'rev': 'master',
+                                        })
         return yaml.dump(yml_data, default_flow_style=False)

--- a/org_status/org_hosts/__init__.py
+++ b/org_status/org_hosts/__init__.py
@@ -33,9 +33,10 @@ class OrgHost:
 
 class RepoStatus:
 
-    def __init__(self, repo_url, repo_status):
+    def __init__(self, repo_url, repo_status, last_commit_date):
         self.repo_url = repo_url
         self.repo_status = repo_status
+        self.last_commit_date = last_commit_date
 
 
 def get_all_supported_hosts():

--- a/org_status/org_hosts/github.py
+++ b/org_status/org_hosts/github.py
@@ -1,4 +1,5 @@
 import json
+from types import MethodType
 
 import requests
 from IGitt.GitHub.GitHub import GitHubToken
@@ -20,6 +21,9 @@ class GitHubOrg(OrgHost):
         self._group = group
         self._token = GitHubToken(token)
         self._org = GitHubOrganization(self._token, self._group)
+
+        for repo in self._org.repositories:
+            repo.get_last_commit_date = MethodType(_get_last_commit_date, repo)
 
         self._status_provider = []
         for i in enumerate(self.StatusProvider):
@@ -56,8 +60,14 @@ class GitHubOrg(OrgHost):
         elif Status.ERROR in repo_status:
             repo_status = Status.ERROR
 
-        return RepoStatus(repo.web_url, repo_status)
+        last_commit_date = repo.get_last_commit_date()
+
+        return RepoStatus(repo.web_url, repo_status, last_commit_date)
 
     @property
     def repositories(self):
         return self._org.repositories
+
+
+def _get_last_commit_date(self):
+    return self.data._data['pushed_at']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ git+https://gitlab.com/gitmate/open-source/IGitt.git#egg=IGitt
 requests
 termcolor
 giturlparse
+pyyaml
+gitman

--- a/tests/fixtures/present_status_output_no_sort.txt
+++ b/tests/fixtures/present_status_output_no_sort.txt
@@ -1,0 +1,4 @@
+https://github.com/foo/r0: passing (last commit: 2018-11-05T08:20:37Z)
+https://github.com/foo/r1: passing (last commit: 2018-11-02T17:31:46Z)
+https://github.com/foo/r2: passing (last commit: 2018-11-06T02:27:42Z)
+0 Passing, 0 Failing, 0 Error, 0 Unknown of 3 Repositories

--- a/tests/fixtures/present_status_output_sorted.txt
+++ b/tests/fixtures/present_status_output_sorted.txt
@@ -1,0 +1,4 @@
+https://github.com/foo/r2: passing (last commit: 2018-11-06T02:27:42Z)
+https://github.com/foo/r0: passing (last commit: 2018-11-05T08:20:37Z)
+https://github.com/foo/r1: passing (last commit: 2018-11-02T17:31:46Z)
+0 Passing, 0 Failing, 0 Error, 0 Unknown of 3 Repositories

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest import mock
+from io import StringIO
 
 from argparse import ArgumentParser
 
@@ -7,7 +8,9 @@ from org_status.org_status import (get_argument_parser,
                                    generate_fetch_jobs,
                                    get_host_token,
                                    get_supported_status_providers,
-                                   get_status_provider_statuses)
+                                   get_status_provider_statuses,
+                                   present_status,
+                                   )
 from org_status.org_hosts import get_all_supported_hosts
 
 
@@ -56,3 +59,38 @@ def test_get_status_provider_statuses():
         expected_status_provider_statuses.add((status_provider, status))
 
     assert actual_status_provider_statuses == expected_status_provider_statuses
+
+
+class MockRepoStatus():
+    def __init__(self, value):
+        self.value = value
+
+
+class MockStatus():
+    def __init__(self, repo_url, repo_status, last_commit_date):
+        self.repo_url = repo_url
+        self.repo_status = MockRepoStatus(repo_status)
+        self.last_commit_date = last_commit_date
+
+
+def test_present_status():
+    statuses = [MockStatus('https://github.com/foo/r0',
+                           'passing', '2018-11-05T08:20:37Z'),
+                MockStatus('https://github.com/foo/r1',
+                           'passing', '2018-11-02T17:31:46Z'),
+                MockStatus('https://github.com/foo/r2',
+                           'passing', '2018-11-06T02:27:42Z')]
+
+    with mock.patch('sys.stdout', new=StringIO()) as output:
+        present_status(statuses, True, False)
+        actual = output.getvalue().strip()
+        with open('tests/fixtures/present_status_output_no_sort.txt', 'r') as f:
+            expected = f.read()
+        assert actual == expected
+
+    with mock.patch('sys.stdout', new=StringIO()) as output:
+        present_status(statuses, True, True)
+        actual = output.getvalue().strip()
+        with open('tests/fixtures/present_status_output_sorted.txt', 'r') as f:
+            expected = f.read()
+        assert actual == expected


### PR DESCRIPTION
This adds the ability to clone every repo (which
can be used for other purposes later) and determine
the date of the last commit, which is then recorded
and can be used to sort the export results.

Closes https://github.com/ksdme/org-status/issues/7